### PR TITLE
Fix the extended death time of coral fans caused partly by the fix of #61

### DIFF
--- a/src/main/java/com/jsorrell/carpetskyadditions/mixin/DeadCoralMixin.java
+++ b/src/main/java/com/jsorrell/carpetskyadditions/mixin/DeadCoralMixin.java
@@ -3,6 +3,7 @@ package com.jsorrell.carpetskyadditions.mixin;
 import com.jsorrell.carpetskyadditions.helpers.DeadCoralToSandHelper;
 import com.jsorrell.carpetskyadditions.settings.SkyAdditionsSettings;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.CoralFanBlock;
 import net.minecraft.block.CoralParentBlock;
 import net.minecraft.block.DeadCoralBlock;
 import net.minecraft.block.DeadCoralFanBlock;
@@ -30,7 +31,7 @@ public abstract class DeadCoralMixin extends CoralParentBlock {
 
   @Override
   public BlockState getStateForNeighborUpdate(BlockState state, Direction direction, BlockState neighborState, WorldAccess world, BlockPos pos, BlockPos neighborPos) {
-    if (SkyAdditionsSettings.coralErosion) {
+    if (SkyAdditionsSettings.coralErosion && !((CoralParentBlock) this instanceof CoralFanBlock)) {
       world.createAndScheduleBlockTick(pos, this, DeadCoralToSandHelper.getSandDropDelay(world.getRandom()));
     }
     return super.getStateForNeighborUpdate(state, direction, neighborState, world, pos, neighborPos);

--- a/src/main/java/com/jsorrell/carpetskyadditions/mixin/DeadCoralWallFanBlockMixin.java
+++ b/src/main/java/com/jsorrell/carpetskyadditions/mixin/DeadCoralWallFanBlockMixin.java
@@ -3,6 +3,7 @@ package com.jsorrell.carpetskyadditions.mixin;
 import com.jsorrell.carpetskyadditions.helpers.DeadCoralToSandHelper;
 import com.jsorrell.carpetskyadditions.settings.SkyAdditionsSettings;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.CoralWallFanBlock;
 import net.minecraft.block.DeadCoralFanBlock;
 import net.minecraft.block.DeadCoralWallFanBlock;
 import net.minecraft.util.math.BlockPos;
@@ -21,7 +22,7 @@ public class DeadCoralWallFanBlockMixin extends DeadCoralFanBlock {
 
   @Inject(method = "getStateForNeighborUpdate", at = @At(value = "HEAD"))
   private void scheduleTickOnBlockUpdate(BlockState state, Direction direction, BlockState neighborState, WorldAccess world, BlockPos pos, BlockPos neighborPos, CallbackInfoReturnable<BlockState> cir) {
-    if (SkyAdditionsSettings.coralErosion) {
+    if (SkyAdditionsSettings.coralErosion && !((DeadCoralWallFanBlock) (Object) this instanceof CoralWallFanBlock)) {
       world.createAndScheduleBlockTick(pos, this, DeadCoralToSandHelper.getSandDropDelay(world.getRandom()));
     }
   }


### PR DESCRIPTION
Hi, I've encountered the following problem - when a waterlogged alive coral fan's water gets sucked in by a dispenser, the redstone updates always propagate to the coral first, causing a block update because of these code snippets:
https://github.com/jsorrell/CarpetSkyAdditions/blob/e9df9dca13135b23714ee6822b99721cd250b1ec/src/main/java/com/jsorrell/carpetskyadditions/mixin/DeadCoralMixin.java#L31-L37
https://github.com/jsorrell/CarpetSkyAdditions/blob/e9df9dca13135b23714ee6822b99721cd250b1ec/src/main/java/com/jsorrell/carpetskyadditions/mixin/DeadCoralWallFanBlockMixin.java#L22-L27
In this case, that scheduled block event blocks the one which would happen after the water is sucked into the dispenser and which all the other alive coral variants are supposed to get instead.
The fix I've offered is to just not let alive coral fan blocks schedule the extra block event which is intended for the dead variants.