### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/en_us/datapack.md
+++ b/docs/en_us/datapack.md
@@ -303,7 +303,7 @@ Music discs must be clicked onto a Jukebox, not hoppered in.
 
 Completing rewards *Dune Armor Trim Smithing Template*
 
-An exact replica Desert Pyramid must be built as described [here](https://minecraft.fandom.com/wiki/Desert_pyramid/Structure).
+An exact replica Desert Pyramid must be built as described [here](https://minecraft.wiki/w/Desert_pyramid/Structure).
 The structure can face any direction. Only layers from the Blue Terracotta layer to the top matter.
 
 The advancement is granted when a Husk is sacrificed on the Blue Terracotta in the center of the pyramid.

--- a/docs/en_us/features.md
+++ b/docs/en_us/features.md
@@ -338,7 +338,7 @@ When a Calcite block has at least 8 of the same type of Coral block within a 3x3
 it can convert to that Coral block upon a random tick (if it would survive).
 
 The chance of conversion depends on the suitability of the location.
-The suitability is based on the [generation temperature and continentalness parameters](https://minecraft.fandom.com/wiki/Biome#Overworld_3).
+The suitability is based on the [generation temperature and continentalness parameters](https://minecraft.wiki/w/Biome#Overworld_3).
 The ideal spot is defined as a temperature of 0.65 and a continentalness of -0.3,
 which translates to just off the coast, in warm locations.
 These values are visible on the F3 screen in singleplayer.


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: <https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom>. This PR updates all the URLs to the new domain: minecraft.wiki